### PR TITLE
feat(Datepicker): Add seconds to format

### DIFF
--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -687,7 +687,8 @@ export class Md2Datepicker implements AfterContentInit, ControlValueAccessor {
       .replace('MM', this._prependZero((date.getMonth() + 1) + ''))
       .replace('DD', this._prependZero(date.getDate() + ''))
       .replace('HH', this._prependZero(date.getHours() + ''))
-      .replace('mm', this._prependZero(date.getMinutes() + ''));
+      .replace('mm', this._prependZero(date.getMinutes() + ''))
+      .replace('ss', this._prependZero(date.getSeconds() + ''));
   }
 
   /**


### PR DESCRIPTION
This commit adds seconds to format datepicker.

Example Usage: 

``` html
<md2-datepicker format="DD/MM/YYYY HH:mm:ss"></md2-datepicker>
```
