### PR TITLE
feat: zero padded hours and minutes

### DIFF
--- a/src/lib/datepicker/datepicker.html
+++ b/src/lib/datepicker/datepicker.html
@@ -56,9 +56,9 @@
               [class.active]="!_isCalendarVisible">
           <span class="md2-datepicker-header-hour"
                 [class.active]="_clockView === 'hour'"
-                (click)="_toggleHours('hour')">{{ date.getHours() }}</span>:<span class="md2-datepicker-header-minute"
+                (click)="_toggleHours('hour')">{{ hours }}</span>:<span class="md2-datepicker-header-minute"
                                                                                   [class.active]="_clockView === 'minute'"
-                                                                                  (click)="_toggleHours('minute')">{{ date.getMinutes() }}</span>
+                                                                                  (click)="_toggleHours('minute')">{{ minutes }}</span>
         </span>
       </div>
     </div>

--- a/src/lib/datepicker/datepicker.ts
+++ b/src/lib/datepicker/datepicker.ts
@@ -214,7 +214,7 @@ export class Md2Datepicker implements OnDestroy, ControlValueAccessor {
     }
   }
 
-  get time() { return this.date.getHours() + ':' + this.date.getMinutes(); }
+  get time() { return this.hours + ':' + this.minutes }
   set time(value: string) {
     this.date = new Date(this.date.getFullYear(), this.date.getMonth(), this.date.getDate(),
       parseInt(value.split(':')[0]), parseInt(value.split(':')[1]));
@@ -223,6 +223,14 @@ export class Md2Datepicker implements OnDestroy, ControlValueAccessor {
     // } else {
     //  this.date.setMinutes(parseInt(value.split(':')[1]));
     // }
+  }
+
+  private padWithZero(n: number){ return (n < 10 ? '0' : '') + n }
+  get minutes(): string {
+    return this.padWithZero(this._date.getMinutes());
+  }
+  get hours(): string {
+    return this.padWithZero(this._date.getHours());
   }
 
   @Input()


### PR DESCRIPTION
Padded single digit hours and minutes in the datepicker header with zeros.

Work requested in issue #166