### PR TITLE
Update common-module.ts

### DIFF
--- a/src/lib/core/common-behaviors/common-module.ts
+++ b/src/lib/core/common-behaviors/common-module.ts
@@ -1,5 +1,5 @@
 import {NgModule, InjectionToken, Optional, Inject, isDevMode} from '@angular/core';
-import {DOCUMENT} from '@angular/platform-browser';
+import {DOCUMENT} from '@angular/common';
 import {CompatibilityModule} from '../compatibility/compatibility';
 
 


### PR DESCRIPTION
Bug, feature request, or proposal:
Refactor any references to DOCUMENT in order to comply with Angular 8 changes

ERROR in ./node_modules/md2/core/common-behaviors/common-module.js 64:46-54
"export 'DOCUMENT' was not found in '@angular/platform-browser'


Compatibility with Angular 8

Which versions of Angular, MD2, OS, browsers are affected?
Angular 8, MD2 0.33

Is there anything else we should know?
DOCUMENT is removed from @angular/platform-browser If you use DOCUMENT from @angular/platform-browser, you should start to import this from @angular/common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/md2/335)
<!-- Reviewable:end -->
